### PR TITLE
feature: 그룹 목록 조회 기능 구현

### DIFF
--- a/src/components/all/Header.module.css
+++ b/src/components/all/Header.module.css
@@ -26,5 +26,5 @@
   flex: 1;
   display: flex;
   justify-content: center;
-  margin: 0px 50px;
+  margin-left: 38px;
 }

--- a/src/components/group/CardList.jsx
+++ b/src/components/group/CardList.jsx
@@ -4,7 +4,7 @@ import GroupCard from "@/components/group/GroupCard";
 import LoadMoreButton from "@/components/group/LoadMoreButton";
 import styles from "./CardList.module.css";
 
-const CardList = ({ isPublic, variant, cards }) => {
+const CardList = ({ variant, cards }) => {
   const getEmptyStateText = () => {
     if (variant === "group")
       return {
@@ -17,12 +17,6 @@ const CardList = ({ isPublic, variant, cards }) => {
         subText: "첫 번째 추억을 올려보세요!",
       };
   };
-
-  const getFilteredList = () => {
-    if (isPublic) return cards.filter((card) => card.isPublic === true);
-    return cards.filter((card) => card.isPublic === false);
-  };
-  const filteredList = getFilteredList();
 
   const renderEmptyState = () => {
     const { mainText, subText } = getEmptyStateText();
@@ -43,7 +37,7 @@ const CardList = ({ isPublic, variant, cards }) => {
   const renderCards = () => (
     <div className={styles.cardList}>
       <div className={styles.cardGrid}>
-        {filteredList.map((card) => (
+        {cards.map((card) => (
           <GroupCard key={card.id} card={card} />
         ))}
       </div>

--- a/src/components/group/CardList.jsx
+++ b/src/components/group/CardList.jsx
@@ -1,7 +1,6 @@
 import empty from "@assets/empty.svg";
 import Button from "@components/all/Button";
 import GroupCard from "@/components/group/GroupCard";
-import LoadMoreButton from "@/components/group/LoadMoreButton";
 import styles from "./CardList.module.css";
 
 const CardList = ({ variant, cards }) => {
@@ -41,7 +40,6 @@ const CardList = ({ variant, cards }) => {
           <GroupCard key={card.id} card={card} />
         ))}
       </div>
-      <LoadMoreButton />
     </div>
   );
 

--- a/src/components/group/CardList.module.css
+++ b/src/components/group/CardList.module.css
@@ -4,7 +4,6 @@
   width: 100%;
   min-width: 965px;
   padding: 0 10%;
-  margin-bottom: 40px;
   box-sizing: border-box;
 }
 

--- a/src/components/group/GroupCard.jsx
+++ b/src/components/group/GroupCard.jsx
@@ -7,9 +7,9 @@ export default function GroupCard({ card }) {
     return (
       <div className={styles.groupCard} style={{ height: "156px" }}>
         <div className={styles.statesContainer}>
-          <span className="typo-14-regular">{`D+${calculateDDay(
-            card.createdAt
-          )}`}</span>
+          <span className="typo-14-regular">
+            {calculateDDay(card.createdAt)}
+          </span>
           <span className="typo-14-regular">|</span>
           <span className="typo-14-regular">비공개</span>
         </div>

--- a/src/components/group/LoadMoreButton.jsx
+++ b/src/components/group/LoadMoreButton.jsx
@@ -1,24 +1,34 @@
-export default function LoadMoreButton() {
-  const handleLoadMore = () => {};
-
+export default function LoadMoreButton({ onClick, disabled }) {
   return (
-    <button
-      style={{
-        display: "flex",
-        width: "100%",
-        height: "60px",
-        justifyContent: "center",
-        alignItems: "center",
-        boxSizing: "border-box",
-        borderRadius: "6px",
-        border: "1px solid var(--black)",
-        backgroundColor: "var(--gray-50)",
-        cursor: "pointer",
-      }}
-      className="typo-14-bold"
-      onClick={handleLoadMore}
-    >
-      더보기
-    </button>
+    !disabled && (
+      <div
+        style={{
+          display: "flex",
+          width: "100%",
+          minWidth: "965px",
+          justifyContent: "center",
+          alignItems: "center",
+          boxSizing: "border-box",
+          backgroundColor: "var(--gray-50)",
+          padding: "0 10%",
+          marginBottom: "40px",
+        }}
+      >
+        <button
+          style={{
+            width: "100%",
+            height: "60px",
+            borderRadius: "6px",
+            border: "1px solid var(--black)",
+            backgroundColor: "var(--gray-50)",
+            cursor: "pointer",
+          }}
+          className="typo-14-bold"
+          onClick={onClick}
+        >
+          더보기
+        </button>
+      </div>
+    )
   );
 }

--- a/src/components/group/SearchBar.jsx
+++ b/src/components/group/SearchBar.jsx
@@ -1,5 +1,6 @@
+import { useState, useEffect } from "react";
 import styles from "./SearchBar.module.css";
-import search from "@/assets/search.svg";
+import searchIcon from "@/assets/search.svg";
 
 const ToggleButton = ({ isPublic, setIsPublic }) => {
   const setButtonClass = (buttonState) => {
@@ -30,33 +31,56 @@ const ToggleButton = ({ isPublic, setIsPublic }) => {
   );
 };
 
-const SearchInput = () => {
+const SearchInput = ({ search, setSearch }) => {
+  const onChangeSearch = (e) => {
+    setSearch(e.target.value);
+  };
+
   return (
     <div className={styles.searchInput}>
       <div>
-        <img src={search} alt="검색" />
+        <img src={searchIcon} alt="검색" />
       </div>
-      <input type="text" placeholder="그룹명을 검색해 주세요" />
+      <input
+        type="text"
+        value={search}
+        onChange={onChangeSearch}
+        placeholder="그룹명을 검색해 주세요"
+      />
     </div>
   );
 };
 
-const FilterDropdown = () => {
+const FilterDropdown = ({ setOrder }) => {
+  const onChangeSelect = (e) => {
+    setOrder(e.target.value);
+  };
   return (
-    <select className={`typo-14-regular ${styles.filterDropdown}`}>
-      <option>공감순</option>
-      <option>최신순</option>
-      <option>댓글순</option>
+    <select
+      onChange={onChangeSelect}
+      className={`typo-14-regular ${styles.filterDropdown}`}
+    >
+      <option value="likeCount">공감순</option>
+      <option value="createdAt">최신순</option>
+      <option value="postCount">추억순</option>
     </select>
   );
 };
 
-const SearchBar = ({ isPublic, setIsPublic }) => {
+const SearchBar = ({ setFilter }) => {
+  const [isPublic, setIsPublic] = useState(true);
+  const [search, setSearch] = useState("");
+  const [order, setOrder] = useState("likeCount");
+
+  useEffect(() => {
+    setFilter({ isPublic, search, order });
+  }, [isPublic, search, order, setFilter]);
+
   return (
     <div className={styles.searchBar}>
       <ToggleButton isPublic={isPublic} setIsPublic={setIsPublic} />
-      <SearchInput />
-      <FilterDropdown />
+      <SearchInput search={search} setSearch={setSearch} />
+      <FilterDropdown setOrder={setOrder} />
     </div>
   );
 };

--- a/src/components/group/SearchBar.jsx
+++ b/src/components/group/SearchBar.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import styles from "./SearchBar.module.css";
 import searchIcon from "@/assets/search.svg";
 
-const ToggleButton = ({ isPublic, setIsPublic }) => {
+const ToggleButton = ({ isPublic, updateisPublic }) => {
   const setButtonClass = (buttonState) => {
     return `typo-14-bold ${styles.toggleButton} ${
       isPublic === buttonState ? styles.toggleSelected : ""
@@ -13,17 +13,13 @@ const ToggleButton = ({ isPublic, setIsPublic }) => {
     <div className={styles.toggleContainer}>
       <button
         className={setButtonClass(true)}
-        onClick={() => {
-          setIsPublic(true);
-        }}
+        onClick={() => updateisPublic(true)}
       >
         공개
       </button>
       <button
         className={setButtonClass(false)}
-        onClick={() => {
-          setIsPublic(false);
-        }}
+        onClick={() => updateisPublic(false)}
       >
         비공개
       </button>
@@ -31,9 +27,9 @@ const ToggleButton = ({ isPublic, setIsPublic }) => {
   );
 };
 
-const SearchInput = ({ search, setSearch }) => {
+const SearchInput = ({ search, updateSearch }) => {
   const onChangeSearch = (e) => {
-    setSearch(e.target.value);
+    updateSearch(e.target.value);
   };
 
   return (
@@ -51,18 +47,19 @@ const SearchInput = ({ search, setSearch }) => {
   );
 };
 
-const FilterDropdown = ({ setOrder }) => {
+const FilterDropdown = ({ updateOrder }) => {
   const onChangeSelect = (e) => {
-    setOrder(e.target.value);
+    updateOrder(e.target.value);
   };
   return (
     <select
       onChange={onChangeSelect}
       className={`typo-14-regular ${styles.filterDropdown}`}
     >
-      <option value="likeCount">공감순</option>
-      <option value="createdAt">최신순</option>
-      <option value="postCount">추억순</option>
+      <option value="mostLiked">공감순</option>
+      <option value="latest">최신순</option>
+      <option value="mostPosted">추억순</option>
+      <option value="mostBadge">뱃지순</option>
     </select>
   );
 };
@@ -72,15 +69,25 @@ const SearchBar = ({ setFilter }) => {
   const [search, setSearch] = useState("");
   const [order, setOrder] = useState("likeCount");
 
-  useEffect(() => {
-    setFilter({ isPublic, search, order });
-  }, [isPublic, search, order, setFilter]);
+  const updateisPublic = (state) => {
+    setIsPublic(state);
+    setFilter((prev) => ({ ...prev, isPublic: state }));
+  };
 
+  const updateSearch = (state) => {
+    setSearch(state);
+    setFilter((prev) => ({ ...prev, search: state }));
+  };
+
+  const updateOrder = (state) => {
+    setOrder(state);
+    setFilter((prev) => ({ ...prev, order: state }));
+  };
   return (
     <div className={styles.searchBar}>
-      <ToggleButton isPublic={isPublic} setIsPublic={setIsPublic} />
-      <SearchInput search={search} setSearch={setSearch} />
-      <FilterDropdown setOrder={setOrder} />
+      <ToggleButton isPublic={isPublic} updateisPublic={updateisPublic} />
+      <SearchInput search={search} updateSearch={updateSearch} />
+      <FilterDropdown updateOrder={updateOrder} />
     </div>
   );
 };

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,129 +1,83 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Header from "@components/all/Header";
 import SearchBar from "@/components/group/SearchBar";
 import CardList from "@/components/group/CardList";
+import LoadMoreButton from "@/components/group/LoadMoreButton";
+import { getGroups } from "@/utils/api";
 
-const mockData = [
-  {
-    id: 1,
-    name: "에델바이스",
-    imageUrl:
-      "https://kukka-2-media-123.s3.amazonaws.com/media/contents/event_template/7f9e2405-0bcb-41b5-a8fd-a49873d6692c.jpg",
-    isPublic: true,
-    likeCount: 1500,
-    badgeCount: 2,
-    postCount: 8,
-    createdAt: "2023-01-01T07:47:49.803Z",
-    introduction: "서로 한 마음으로 응원하고 아끼는 달봉이네 가족입니다.",
-  },
-  {
-    id: 2,
-    name: "바위솔",
-    // imageUrl: "https://example.com/images/sedum.jpg",
-    imageUrl: "",
-    isPublic: true,
-    likeCount: 800,
-    badgeCount: 4,
-    postCount: 12,
-    createdAt: "2022-02-15T09:20:30.003Z",
-    introduction: "바위처럼 굳건히 함께하는 정원사들의 모임입니다.",
-  },
-  {
-    id: 3,
-    name: "구절초",
-    // imageUrl: "https://example.com/images/gujeolcho.jpg",
-    imageUrl: "",
-    isPublic: false,
-    likeCount: 230,
-    badgeCount: 1,
-    postCount: 5,
-    createdAt: "2023-03-10T10:55:15.100Z",
-    introduction: "자연과 함께하는 삶을 추구하는 소박한 사람들의 모임입니다.",
-  },
-  {
-    id: 4,
-    name: "라벤더",
-    // imageUrl: "https://example.com/images/lavender.jpg",
-    imageUrl: "",
-    isPublic: true,
-    likeCount: 1200,
-    badgeCount: 6,
-    postCount: 25,
-    createdAt: "2023-05-20T14:12:40.200Z",
-    introduction: "평온한 향기 속에서 마음을 나누는 힐링 그룹입니다.",
-  },
-  {
-    id: 5,
-    name: "안개꽃",
-    // imageUrl: "https://example.com/images/babysbreath.jpg",
-    imageUrl: "",
-    isPublic: false,
-    likeCount: 560,
-    badgeCount: 3,
-    postCount: 9,
-    createdAt: "2023-07-05T11:30:45.890Z",
-    introduction: "작지만 소중한 순간들을 기록하는 안개꽃 모임입니다.",
-  },
-  {
-    id: 6,
-    name: "장미",
-    // imageUrl: "https://example.com/images/rose.jpg",
-    imageUrl: "",
-    isPublic: false,
-    likeCount: 450,
-    badgeCount: 2,
-    postCount: 15,
-    createdAt: "2023-09-01T16:25:10.123Z",
-    introduction: "내면의 아름다움을 가꾸는 비공개 모임입니다.",
-  },
-  {
-    id: 7,
-    name: "선인장",
-    // imageUrl: "https://example.com/images/cactus.jpg",
-    imageUrl: "",
-    isPublic: false,
-    likeCount: 320,
-    badgeCount: 1,
-    postCount: 6,
-    createdAt: "2023-10-12T12:45:30.456Z",
-    introduction: "가시 속에서 피어나는 단단한 모임, 선인장입니다.",
-  },
-];
+// const getFilteredList = () => {
+//   const compare = (a, b) => {
+//     if (filter.order === "createdAt") {
+//       return new Date(b.createdAt) - new Date(a.createdAt);
+//     }
+//     return b[filter.order] - a[filter.order];
+//   };
+//   if (filter.search === "") {
+//     return mockData
+//       .filter((group) => group.isPublic === filter.isPublic)
+//       .sort(compare);
+//   }
+//   return mockData
+//     .filter(
+//       (group) =>
+//         group.isPublic === filter.isPublic &&
+//         group.name.toLowerCase().includes(filter.search.toLowerCase())
+//     )
+//     .sort(compare);
+// };
+// const filteredList = getFilteredList();
 
 export default function Main() {
+  const [data, setData] = useState([]);
+  const [page, setPage] = useState(1);
+  const [disabled, setDisabled] = useState(false);
   const [filter, setFilter] = useState({
     isPublic: true,
     search: "",
-    order: "likeCount",
+    order: "mostLiked",
   });
 
-  const getFilteredList = () => {
-    const compare = (a, b) => {
-      if (filter.order === "createdAt") {
-        return new Date(b.createdAt) - new Date(a.createdAt);
-      }
-      return b[filter.order] - a[filter.order];
-    };
-
-    if (filter.search === "") {
-      return mockData
-        .filter((group) => group.isPublic === filter.isPublic)
-        .sort(compare);
+  const handleLoad = async (options) => {
+    let result;
+    try {
+      result = await getGroups(options);
+    } catch (error) {
+      console.log(error);
     }
-    return mockData
-      .filter(
-        (group) =>
-          group.isPublic === filter.isPublic &&
-          group.name.toLowerCase().includes(filter.search.toLowerCase())
-      )
-      .sort(compare);
+    const { currentPage, totalPages, data } = result;
+    if (currentPage === 1) {
+      setData(data);
+    } else {
+      setData((prevData) => [...prevData, ...data]);
+    }
+    setPage(currentPage + 1);
+    if (currentPage === totalPages) setDisabled(true);
+    console.log(data);
   };
-  const filteredList = getFilteredList();
+
+  const handleLoadMore = () => {
+    handleLoad({
+      page,
+      sortBy: filter.order,
+      isPublic: filter.isPublic,
+      keyword: filter.search,
+    });
+  };
+
+  useEffect(() => {
+    handleLoad({
+      sortBy: filter.order,
+      isPublic: filter.isPublic,
+      keyword: filter.search,
+    });
+  }, [filter]);
+
   return (
     <>
       <Header button />
       <SearchBar setFilter={setFilter} />
-      <CardList variant="group" cards={filteredList} />
+      <CardList variant="group" cards={data} />
+      <LoadMoreButton disabled={disabled} onClick={handleLoadMore} />
     </>
   );
 }

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -25,7 +25,7 @@ const mockData = [
     likeCount: 800,
     badgeCount: 4,
     postCount: 12,
-    createdAt: "2023-02-15T09:20:30.003Z",
+    createdAt: "2022-02-15T09:20:30.003Z",
     introduction: "바위처럼 굳건히 함께하는 정원사들의 모임입니다.",
   },
   {
@@ -91,12 +91,39 @@ const mockData = [
 ];
 
 export default function Main() {
-  const [isPublic, setIsPublic] = useState(true);
+  const [filter, setFilter] = useState({
+    isPublic: true,
+    search: "",
+    order: "likeCount",
+  });
+
+  const getFilteredList = () => {
+    const compare = (a, b) => {
+      if (filter.order === "createdAt") {
+        return new Date(b.createdAt) - new Date(a.createdAt);
+      }
+      return b[filter.order] - a[filter.order];
+    };
+
+    if (filter.search === "") {
+      return mockData
+        .filter((group) => group.isPublic === filter.isPublic)
+        .sort(compare);
+    }
+    return mockData
+      .filter(
+        (group) =>
+          group.isPublic === filter.isPublic &&
+          group.name.toLowerCase().includes(filter.search.toLowerCase())
+      )
+      .sort(compare);
+  };
+  const filteredList = getFilteredList();
   return (
     <>
       <Header button />
-      <SearchBar isPublic={isPublic} setIsPublic={setIsPublic} />
-      <CardList isPublic={isPublic} variant="group" cards={mockData} />
+      <SearchBar setFilter={setFilter} />
+      <CardList variant="group" cards={filteredList} />
     </>
   );
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,16 @@
+const BASE_URL = "https://613508a7-d02f-4d83-9103-b857cae37561.mock.pstmn.io";
+
+export async function getGroups({
+  page = 1,
+  pageSize = 2,
+  sortBy = "mostLiked",
+  isPublic = true,
+  keyword = "",
+}) {
+  const query = `page=${page}&pageSize=${pageSize}&sortBy=${sortBy}&isPublic=${isPublic}&keyword=${keyword}`;
+  const response = await fetch(`${BASE_URL}/groups?${query}`);
+  const body = await response.json();
+  console.log(query);
+  console.log(body);
+  return body;
+}


### PR DESCRIPTION
## 🔗 ISSUE

Closes #9

## 📌 주요 변경 사항

- API 통신 구현 및 Main 컴포넌트와의 연동
    - `src/utils/api.js`에 그룹 목록 조회를 위한 리퀘스트 함수 `getGroups` 작성
    - `useEffect`로 `filter` 상태 변경 시 자동으로 API 요청 함수 실행하여 데이터 갱신
        
- SearchBar 컴포넌트
    - 상태 업데이트 시 prop으로 전달받은 `setFilter` 함수를 실행하여 Main 컴포넌트에서 `filter` 상태가 업데이트 되도록 함

- LoadMoreButton 컴포넌트
    - `onClick`과 `disabled` props 추가
    - `onClick`으로 추가 데이터 요청 함수를 전달받아 페이지네이션 구현
    - `disabled`로 더 이상 로드할 데이터가 없을 경우 버튼을 렌더링하지 않도록 처리
- CardList 컴포넌트
    - `isPublic` prop을 받아 필터링 처리하는 로직 제거
        → API 요청을 통해 서버에서 필터링된 데이터 받아오도록 변경
        
- Header 컴포넌트 마진 조정
    - 좌측 마진을 38px로 설정하여 피그마 디자인과 일치하도록 조정

## 💡 특이사항

- Postman mock server를 이용해 API 서버 응답을 테스트해보았습니다.
        
- 현재 구현에서는 검색어 입력 시 매 `onChange` 이벤트마다 API 요청을 보내고 있어 비효율적인 것 같아요. 추후 클라이언트 측에서 필터링할 수 있도록 수정 예정입니다!