### PR TITLE
feature: ModifyModal 테스트 및 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: git clone
         uses: actions/checkout@v2
@@ -20,6 +20,6 @@ jobs:
 
       - name: deploy
         env:
-          AWS_ACCESS_KEY_ID: "$"
-          AWS_SECRET_ACCESS_KEY: "$"
-        run: aws s3 cp --recursive --region ap-northeast-2 dist s3://home.manual
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 cp --recursive --region ap-northeast-2 dist s3://peace-of-memory

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Main CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: git clone
+        uses: actions/checkout@v2
+
+      - name: npm install
+        run: npm install
+
+      - name: npm build
+        run: npm run build
+
+      - name: deploy
+        env:
+          AWS_ACCESS_KEY_ID: "$"
+          AWS_SECRET_ACCESS_KEY: "$"
+        run: aws s3 cp --recursive --region ap-northeast-2 dist s3://home.manual

--- a/src/components/feed/ModifyModal.jsx
+++ b/src/components/feed/ModifyModal.jsx
@@ -2,9 +2,14 @@ import { useState, useRef, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import styles from "./ModifyModal.module.css";
 import ModifyButton from "../all/Button";
+import { uploadImage } from "@/utils/api";
 
 export default function ModifyModal({ closeModal }) {
-  const { postId } = useParams();
+  // const { postId } = useParams();
+  // 요청 id를 1로 고정
+  const postId = 1;
+  // 목서버 주소
+  const BASE_URL = "https://d25099c5-86ab-44ab-95e4-dcb3a3f97104.mock.pstmn.io";
   const navigate = useNavigate();
 
   const [nickname, setNickname] = useState("");
@@ -22,7 +27,7 @@ export default function ModifyModal({ closeModal }) {
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const response = await fetch(`/api/posts/${postId}`);
+        const response = await fetch(`${BASE_URL}/api/posts/${postId}`);
         const data = await response.json();
         setNickname(data.nickname);
         setTitle(data.title);
@@ -72,10 +77,13 @@ export default function ModifyModal({ closeModal }) {
 
   const updatePost = async () => {
     let imageURL = "";
+
     if (selectedFile) {
+      // api.js 에 정의된 uploadImage 사용
+      imageURL = await uploadImage(selectedFile);
+      /*
       const formData = new FormData();
       formData.append("file", selectedFile);
-
       try {
         const imageUploadResponse = await fetch("/api/uploadImage", {
           method: "POST",
@@ -94,6 +102,7 @@ export default function ModifyModal({ closeModal }) {
         setErrorMessage("이미지 업로드 중 오류가 발생했습니다.");
         return;
       }
+      */
     }
 
     const updateData = {
@@ -109,14 +118,13 @@ export default function ModifyModal({ closeModal }) {
     };
 
     try {
-      const response = await fetch(`/api/posts/${postId}`, {
-        method: "PATCH",
+      const response = await fetch(`${BASE_URL}/api/posts/${postId}`, {
+        method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify(updateData),
       });
-
       if (response.ok) {
         console.log("게시물 수정 성공");
         navigate("/feed");
@@ -134,7 +142,7 @@ export default function ModifyModal({ closeModal }) {
   const handleSubmit = async (event) => {
     event.preventDefault();
     await updatePost();
-    closeModal(); 
+    closeModal();
   };
 
   return (

--- a/src/components/group/detail/GroupDetail.jsx
+++ b/src/components/group/detail/GroupDetail.jsx
@@ -32,6 +32,9 @@ export default function GroupDetail({ groupId }) {
     const result = await getGroupDetails(groupId);
     setGroupData(result);
     console.log(result);
+    return () => {
+      groupId = "";
+    };
   }, [groupId]);
 
   return (

--- a/src/pages/Group.jsx
+++ b/src/pages/Group.jsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router-dom";
-import { Component, useEffect } from "react";
+import { useEffect } from "react";
 import { getPosts } from "@/utils/api";
 import { useLoadData } from "@/hooks/useLoadData";
 import Header from "@components/all/Header";
@@ -11,8 +11,6 @@ import PageLayout from "../components/group/shared/PageLayout";
 
 export default function Group() {
   const { groupId } = useParams();
-
-  console.log(groupId);
 
   const { data, page, disabled, filter, setFilter, handleLoad } =
     useLoadData(getPosts);

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,10 +1,10 @@
-const BASE_URL = "https://613508a7-d02f-4d83-9103-b857cae37561.mock.pstmn.io";
-//const BASE_URL = "https://backend-vai1.onrender.com";
+const BASE_URL = "https://d25099c5-86ab-44ab-95e4-dcb3a3f97104.mock.pstmn.io";
+// const BASE_URL = "https://backend-vai1.onrender.com/api";
 const PAGE_SIZE = 8;
 
 export async function getGroups({
   page = 1,
-  pageSize = PAGE_SIZE,
+  pageSize = 2,
   sortBy = "mostLiked",
   isPublic = true,
   keyword = "",
@@ -27,6 +27,7 @@ export async function createGroups(groupData) {
     throw new Error("데이터를 생성하는데 실패했습니다");
   }
   const body = await response.json();
+  console.log(body);
   return body;
 }
 
@@ -34,7 +35,7 @@ export async function uploadImage(file) {
   const formData = new FormData();
   formData.append("image", file);
 
-  const response = await fetch(`${BASE_URL}/image`, {
+  const response = await fetch(`https://backend-vai1.onrender.com/api/image`, {
     method: "POST",
     body: formData,
   });

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,9 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    port: 3000,
+  },
   plugins: [react()],
   resolve: {
     alias: [


### PR DESCRIPTION
## 📌 주요 변경 사항

- ModifyModal 컴포넌트
    - BASE_URL에 Postman 목 서버 주소 설정한 후 게시물 수정 기능 테스트해 보았습니다.
    → PUT 요청 테스트 가능 url : BASE_URL/api/posts/1
    - `postId`는 1로 고정하여 응답을 받을 수 있도록 임시 처리했습니다.
    - 게시물 수정 요청 메서드를 `PATCH`에서 `PUT`으로 변경했습니다.
- api.js 파일
    - `uploadImage` 함수의 BASE_URL을 실제 서버 주소로 변경했습니다.
    - 나머지 api 요청은 백엔드 구현 전이므로 목 서버 주소로 설정했습니다.
    
- vite.config.js 파일
    - 개발 서버 포트를 3000으로 설정하여 로컬 환경 테스트가 가능하도록 했습니다.

- GitHub Actions를 이용한 배포 자동화 워크플로우 추가
  - `.github/workflows/main.yml` 파일 생성
  - main 브랜치 push 시 자동으로 빌드 및 AWS S3 배포 수행
## 💡 특이사항

- ModifyModal 컴포넌트의 이미지 업로드 로직을 `uploadImage` 함수를 import 해서 대체하여 테스트하고 응답을 확인해 보았습니다. 문제가 없다면 기존 로직을 대체해도 될 것 같습니다.
    
- 데이터 수정 확인 문제
    - 목 서버는 미리 설정된 응답만 반환하고, 이후에 상태를 관리하거나 갱신하지 않기 때문에(데이터 베이스 연동이 안됩니다.ㅠㅠ) 수정 기능에 대한 확실한 테스트는 어려울 것 같습니다..
    - 요청 형식, 응답 구조 등 기본적인 API 동작은 테스트 가능해서, 이 부분에서는 기능에 문제가 없음을 확인할 수 있습니다!